### PR TITLE
chore: find projects via tasks

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -341,14 +341,14 @@ async function findProjectInFolder(workspaceFolder?: vscode.WorkspaceFolder) {
     return [];
   }
   const exclusions: string[] = ["**/node_modules", "**/cdk.out", "**/dist"];
-  const pattern: string = "**/.projen/deps.json";
+  const pattern: string = "**/.projen/tasks.json";
   const depFileList = await vscode.workspace.findFiles(
     new vscode.RelativePattern(workspaceFolder, pattern),
     `{${exclusions.join(",")}}`
   );
 
   const cleanupList = depFileList.map((f) => {
-    return f.with({ path: f.path.replace("/.projen/deps.json", "") });
+    return f.with({ path: f.path.replace("/.projen/tasks.json", "") });
   });
 
   return cleanupList;

--- a/src/jsii/fetcher.ts
+++ b/src/jsii/fetcher.ts
@@ -1,7 +1,6 @@
 import { Readable } from "stream";
 import gunzip from "gunzip-maybe";
 import { tarball } from "pacote";
-// import registryUrl from "registry-url";
 import { extract } from "tar-stream";
 
 async function getRegistryUrl(scope: string | undefined) {
@@ -89,7 +88,6 @@ export async function getJSII(spec: string): Promise<any> {
     }
 
     const tarballData = await tarball(spec, {
-      // registry: registryUrl(scope),
       registry: await getRegistryUrl(scope),
     });
 

--- a/src/jsii/fetcher.ts
+++ b/src/jsii/fetcher.ts
@@ -1,9 +1,14 @@
 import { Readable } from "stream";
 import gunzip from "gunzip-maybe";
 import { tarball } from "pacote";
-import registryUrl from "registry-url";
+// import registryUrl from "registry-url";
 import { extract } from "tar-stream";
 
+async function getRegistryUrl(scope: string | undefined) {
+  const registryUrl = await import("registry-url");
+  const url = registryUrl.default(scope);
+  return url;
+}
 export interface RemoteProjenProjectInfo {
   typeName: string;
   pjid?: string;
@@ -84,7 +89,8 @@ export async function getJSII(spec: string): Promise<any> {
     }
 
     const tarballData = await tarball(spec, {
-      registry: registryUrl(scope),
+      // registry: registryUrl(scope),
+      registry: await getRegistryUrl(scope),
     });
 
     const tarballStream = new Readable();


### PR DESCRIPTION
As far as I understand the deps.json is used to determine if it's a projen project.
Projen relies more on the tasks.json: https://github.com/projen/projen/blob/bec9bc44dcab5c121dc7b9f772bafa2ebe300a36/src/cli/synth.ts#L45


Could that be changed, so that for a projen base project without deps the tasks are shown in the extension?


